### PR TITLE
Use env variable for PIAPI key

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ Este repositório contém uma estrutura inicial para o projeto **Tenda dos Peque
 - `triggers.gs` - Disparo automático de ações ao editar o Google Sheets.
 
 Algumas funções já trazem chamadas reais às APIs, mas o fluxo ainda demanda ajustes e integração com o Google Sheets.
+
+## Variáveis de ambiente
+
+Defina `PIAPI_KEY` como um segredo do GitHub ou variável de ambiente local para que o script `kling_flow.py` consiga acessar a PIAPI.

--- a/kling_flow.py
+++ b/kling_flow.py
@@ -1,0 +1,27 @@
+import os
+import requests
+
+PIAPI_KEY = os.environ["PIAPI_KEY"]
+
+
+def generate_video(prompt: str, personagem: str, background: str, audio: str) -> dict:
+    """Generate a video with Kling using PIAPI."""
+    url = "https://api.piapi.ai/kling/videogen"
+    payload = {
+        "model": "kling",
+        "task_type": "video_generation",
+        "input": {
+            "prompt": prompt,
+            "mode": "professional",
+            "duration": 5,
+            "image_url": personagem,
+            "background_url": background,
+            "audio_url": audio,
+            "lip_sync": True,
+        },
+    }
+    headers = {"x-api-key": PIAPI_KEY}
+
+    response = requests.post(url, json=payload, headers=headers, timeout=30)
+    response.raise_for_status()
+    return response.json()


### PR DESCRIPTION
## Summary
- use `os.environ["PIAPI_KEY"]` inside `kling_flow.py`
- document `PIAPI_KEY` environment variable in README

## Testing
- `python3 -m py_compile kling_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_6841fa63c00c832196fffc207c861e08